### PR TITLE
Added support for uncached iterators

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
+/.idea
+*.DS_Store
+
 /vendor/
-
-/.idea/iterator.iml
-
-/.idea/workspace.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,1 +1,0 @@
-iterator

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="Encoding" useUTFGuessing="true" native2AsciiForPropertiesFiles="false" />
-</project>
-

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectRootManager" version="2" />
-</project>
-

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="ProjectModuleManager">
-    <modules>
-      <module fileurl="file://$PROJECT_DIR$/.idea/iterator.iml" filepath="$PROJECT_DIR$/.idea/iterator.iml" />
-    </modules>
-  </component>
-</project>
-

--- a/.idea/scopes/scope_settings.xml
+++ b/.idea/scopes/scope_settings.xml
@@ -1,5 +1,0 @@
-<component name="DependencyValidationManager">
-  <state>
-    <option name="SKIP_IMPORT_STATEMENTS" value="false" />
-  </state>
-</component>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>
-

--- a/src/Elliotchance/Iterator/AbstractPagedIterator.php
+++ b/src/Elliotchance/Iterator/AbstractPagedIterator.php
@@ -17,6 +17,21 @@ abstract class AbstractPagedIterator implements Countable, ArrayAccess, Iterator
     protected $cachedPages = [];
 
     /**
+     * @var array
+     */
+    protected $currentPage;
+
+    /**
+     * @var int
+     */
+    protected $currentPageNumber;
+
+    /**
+     * @var bool
+     */
+    protected $useCache = true;
+
+    /**
      * @var integer
      */
     protected $index = 0;
@@ -70,10 +85,18 @@ abstract class AbstractPagedIterator implements Countable, ArrayAccess, Iterator
         }
 
         $page = (int) ($offset / $this->getPageSize());
-        if (!array_key_exists($page, $this->cachedPages)) {
-            $this->cachedPages[$page] = $this->getPage($page);
+        if ($this->useCache) {
+            if (!array_key_exists($page, $this->cachedPages)) {
+                $this->cachedPages[$page] = $this->getPage($page);
+            }
+            return $this->cachedPages[$page][$offset % $this->getPageSize()];
         }
-        return $this->cachedPages[$page][$offset % $this->getPageSize()];
+
+        if ($page !== $this->currentPageNumber) {
+            $this->currentPageNumber = $page;
+            $this->currentPage = $this->getPage($page);
+        }
+        return $this->currentPage[$offset % $this->getPageSize()];
     }
 
     /**

--- a/tests/Elliotchance/Iterator/PagedIteratorTest.php
+++ b/tests/Elliotchance/Iterator/PagedIteratorTest.php
@@ -44,94 +44,142 @@ class PagedIterator1 extends AbstractPagedIterator
     }
 }
 
+class PagedIterator2 extends PagedIterator1
+{
+    protected $useCache = false;
+}
+
 class PagedIteratorTest extends TestCase
 {
     /**
      * @var PagedIterator1
      */
-    protected $iterator;
+    protected $cachedIterator;
+
+    /**
+     * @var PagedIterator2
+     */
+    protected $uncachedIterator;
 
     public function setUp()
     {
         parent::setUp();
-        $this->iterator = new PagedIterator1();
+        $this->cachedIterator = new PagedIterator1();
+        $this->uncachedIterator = new PagedIterator2();
     }
 
     public function testCountReturnsAnInteger()
     {
-        $this->assert(count($this->iterator), equals, 8);
+        $this->assert(count($this->cachedIterator), equals, 8);
+        $this->assert(count($this->uncachedIterator), equals, 8);
     }
 
     /**
      * @expectedException \OutOfBoundsException
      * @expectedExceptionMessage Index out of bounds: -1
      */
-    public function testFetchingANegativeIndexThrowsAnException()
+    public function testFetchingANegativeIndexThrowsAnExceptionForCachedIterator()
     {
-        $this->iterator[-1];
+        $this->cachedIterator[-1];
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     * @expectedExceptionMessage Index out of bounds: -1
+     */
+    public function testFetchingANegativeIndexThrowsAnExceptionForUncachedIterator()
+    {
+        $this->uncachedIterator[-1];
     }
 
     /**
      * @expectedException \OutOfBoundsException
      * @expectedExceptionMessage Index out of bounds: 15
      */
-    public function testFetchingAnOutOfBoundsIndexThrowsException()
+    public function testFetchingAnOutOfBoundsIndexThrowsExceptionForCachedIterator()
     {
-        $this->iterator[15];
+        $this->cachedIterator[15];
+    }
+
+    /**
+     * @expectedException \OutOfBoundsException
+     * @expectedExceptionMessage Index out of bounds: 15
+     */
+    public function testFetchingAnOutOfBoundsIndexThrowsExceptionForUncachedIterator()
+    {
+        $this->uncachedIterator[15];
     }
 
     public function testAPageSizeMustBeSet()
     {
-        $this->assert($this->iterator->getPageSize(), equals, 3);
+        $this->assert($this->cachedIterator->getPageSize(), equals, 3);
+        $this->assert($this->uncachedIterator->getPageSize(), equals, 3);
     }
 
     public function testGetFirstElement()
     {
-        $this->assert($this->iterator[0], equals, 1);
+        $this->assert($this->cachedIterator[0], equals, 1);
+        $this->assert($this->uncachedIterator[0], equals, 1);
     }
 
     public function testGetSecondElement()
     {
-        $this->assert($this->iterator[1], equals, 2);
+        $this->assert($this->cachedIterator[1], equals, 2);
+        $this->assert($this->uncachedIterator[1], equals, 2);
     }
 
     public function testGetFirstElementOnSecondPage()
     {
-        $this->assert($this->iterator[3], equals, 4);
+        $this->assert($this->cachedIterator[3], equals, 4);
+        $this->assert($this->uncachedIterator[3], equals, 4);
     }
 
     public function testGetSecondElementOnThirdPage()
     {
-        $this->assert($this->iterator[7], equals, 8);
+        $this->assert($this->cachedIterator[7], equals, 8);
+        $this->assert($this->uncachedIterator[7], equals, 8);
     }
 
     /**
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage Index must be a positive integer: foo
      */
-    public function testFetchingAStringIndexIsNotAllowed()
+    public function testFetchingAStringIndexIsNotAllowedForCachedIterator()
     {
-        $this->iterator['foo'];
+        $this->cachedIterator['foo'];
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Index must be a positive integer: foo
+     */
+    public function testFetchingAStringIndexIsNotAllowedUncachedIterator()
+    {
+        $this->uncachedIterator['foo'];
     }
 
     public function testOffsetOfANegativeIndexReturnsFalse()
     {
-        $this->assert(isset($this->iterator[-1]), is_false);
+        $this->assert(isset($this->cachedIterator[-1]), is_false);
+        $this->assert(isset($this->uncachedIterator[-1]), is_false);
     }
 
     public function testOffsetThatIsValidReturnsTrue()
     {
-        $this->assert(isset($this->iterator[0]), is_true);
+        $this->assert(isset($this->cachedIterator[0]), is_true);
+        $this->assert(isset($this->uncachedIterator[0]), is_true);
     }
 
     public function testOffsetThatIsOutOfBoundsReturnsFalse()
     {
-        $this->assert(isset($this->iterator[15]), is_false);
+        $this->assert(isset($this->cachedIterator[15]), is_false);
+        $this->assert(isset($this->uncachedIterator[15]), is_false);
     }
 
     public function testOffsetThatIsAfterTheLastElementReturnsFalse()
     {
-        $this->assert(isset($this->iterator[10]), is_false);
+        $this->assert(isset($this->cachedIterator[10]), is_false);
+        $this->assert(isset($this->uncachedIterator[10]), is_false);
     }
 
     public function testValuesOfTheSameIndexAreCached()
@@ -152,6 +200,13 @@ class PagedIteratorTest extends TestCase
 
         $this->verify($iterator[0], equals, 1);
         $this->verify($iterator[1], equals, 2);
+
+        $iterator = $this->niceMock('\Elliotchance\Iterator\PagedIterator2')
+            ->expect('getPage')->with(0)->andReturn([1, 2])
+            ->get();
+
+        $this->verify($iterator[0], equals, 1);
+        $this->verify($iterator[1], equals, 2);
     }
 
     public function testValuesFromAnotherPageMustBeRequested()
@@ -163,9 +218,17 @@ class PagedIteratorTest extends TestCase
 
         $this->verify($iterator[0], equals, 1);
         $this->verify($iterator[3], equals, 4);
+
+        $iterator = $this->niceMock('\Elliotchance\Iterator\PagedIterator2')
+            ->expect('getPage')->with(0)->andReturn([1, 2, 3])
+            ->with(1)->andReturn([4, 5, 6])
+            ->get();
+
+        $this->verify($iterator[0], equals, 1);
+        $this->verify($iterator[3], equals, 4);
     }
 
-    public function testValuesFromMultiplePagesAreSimultaneouslyCached()
+    public function testValuesFromMultiplePagesAreSimultaneouslyCachedInCachedIterator()
     {
         $iterator = $this->niceMock('\Elliotchance\Iterator\PagedIterator1')
             ->expect('getPage')->with(0)->andReturn([1, 2, 3])
@@ -178,10 +241,29 @@ class PagedIteratorTest extends TestCase
         $this->verify($iterator[3], equals, 4);
     }
 
+    public function testValuesFromMultiplePagesAreNotSimultaneouslyCachedInUncachedIterator()
+    {
+        $iterator = $this->niceMock('\Elliotchance\Iterator\PagedIterator2')
+            ->expect('getPage')->with(0)->twice()->andReturn([1, 2, 3])
+            ->with(1)->twice()->andReturn([4, 5, 6])
+            ->get();
+
+        $this->verify($iterator[0], equals, 1);
+        $this->verify($iterator[3], equals, 4);
+        $this->verify($iterator[0], equals, 1);
+        $this->verify($iterator[3], equals, 4);
+    }
+
     public function testTraverseArrayInForeachLoop()
     {
         $result = [];
-        foreach ($this->iterator as $item) {
+        foreach ($this->cachedIterator as $item) {
+            $result[] = $item;
+        }
+        $this->assert($result, equals, [1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $result = [];
+        foreach ($this->uncachedIterator as $item) {
             $result[] = $item;
         }
         $this->assert($result, equals, [1, 2, 3, 4, 5, 6, 7, 8]);
@@ -190,10 +272,19 @@ class PagedIteratorTest extends TestCase
     public function testTraverseArrayInMultipleForeachLoops()
     {
         $result = [];
-        foreach ($this->iterator as $item) {
+        foreach ($this->cachedIterator as $item) {
             $result[] = $item;
         }
-        foreach ($this->iterator as $item) {
+        foreach ($this->cachedIterator as $item) {
+            $result[] = $item;
+        }
+        $this->assert($result, equals, [1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8]);
+
+        $result = [];
+        foreach ($this->uncachedIterator as $item) {
+            $result[] = $item;
+        }
+        foreach ($this->uncachedIterator as $item) {
             $result[] = $item;
         }
         $this->assert($result, equals, [1, 2, 3, 4, 5, 6, 7, 8, 1, 2, 3, 4, 5, 6, 7, 8]);
@@ -203,17 +294,35 @@ class PagedIteratorTest extends TestCase
      * @expectedException \LogicException
      * @expectedExceptionMessage Setting values is not allowed.
      */
-    public function testSettingAnElementThrowsAnException()
+    public function testSettingAnElementThrowsAnExceptionForCachedIterator()
     {
-        $this->iterator[0] = true;
+        $this->cachedIterator[0] = true;
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Setting values is not allowed.
+     */
+    public function testSettingAnElementThrowsAnExceptionForUncachedIterator()
+    {
+        $this->uncachedIterator[0] = true;
     }
 
     /**
      * @expectedException \LogicException
      * @expectedExceptionMessage Unsetting values is not allowed.
      */
-    public function testUnsettingAnElementThrowsAnException()
+    public function testUnsettingAnElementThrowsAnExceptionForCachedIterator()
     {
-        unset($this->iterator[0]);
+        unset($this->cachedIterator[0]);
+    }
+
+    /**
+     * @expectedException \LogicException
+     * @expectedExceptionMessage Unsetting values is not allowed.
+     */
+    public function testUnsettingAnElementThrowsAnExceptionForUncachedIterator()
+    {
+        unset($this->uncachedIterator[0]);
     }
 }


### PR DESCRIPTION
With this change, iterators can be told not to store pages in the `$cachedPages`-Array. To do this, you have to set the `$useCache`-attribute to false.

This is desirable if you want to iterate through a large set of records, for example from a database, and perform certain actions on them, without having all of them stored in memory at some point.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/elliotchance/iterator/1)
<!-- Reviewable:end -->
